### PR TITLE
check if value is already float to not fall into floating point conversion…

### DIFF
--- a/src/SixDreams/Bulk/BulkUpdate.php
+++ b/src/SixDreams/Bulk/BulkUpdate.php
@@ -263,6 +263,10 @@ class BulkUpdate extends AbstractBulk
             return 'NULL';
         }
         if (is_numeric($value)) {
+            if(\is_float($value)) {
+                return $value;       
+            }
+            
             if (\strpos((string) $value, '.') !== false || \strpos((string) $value, ',') !== false) {
                 return (float) $value;
             }


### PR DESCRIPTION
In following example $value is incorrectly saved to database as 144 instead of 145.

```
            $value = 46.0 / 40.0 / 1.0 * 100; // 145.00
            $playerTaskBulkUpdate->addValue($id, [
                'value' => $value
            ]);
```

This is due to how simpleValue function processes input values. Conversion to string of float 145.00 doesn't containt dot or comma, so int casting is being forced.

```
        if (is_numeric($value)) {
            if (\strpos((string) $value, '.') !== false || \strpos((string) $value, ',') !== false) {
                return (float) $value;
            }

            return (int) $value;
        }
```

Sample code for testing:

```
$value = 46.0 / 40.0 / 1.0 * 100;
var_dump($value); // 145
var_dump((float) $value); // 145.00
var_dump((int) $value); // 144
```

Proposed PR will allow float value to end up being saved as is instead of casting 145.00 into int which endup as 144 due to how floating point conversion works.